### PR TITLE
refactor: command building with argument array

### DIFF
--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -8,13 +8,13 @@ const buildLogCommand = (
 	service?: string,
 	environment?: string,
 ) => {
-	let command = `railway logs --${type} --json`;
+	const args = ["logs", `--${type}`, "--json"];
 
-	if (deploymentId) command += ` ${deploymentId}`;
-	if (service) command += ` --service ${service}`;
-	if (environment) command += ` --environment ${environment}`;
+	if (deploymentId) args.push(deploymentId);
+	if (service) args.push("--service", service);
+	if (environment) args.push("--environment", environment);
 
-	return command;
+	return `railway ${args.join(" ")}`;
 };
 
 export type GetLogsOptions = {


### PR DESCRIPTION
Replaced string concatenation with an argument array for building the railway command. This improves readability, reduces potential spacing/formatting bugs, and makes it easier to extend or modify command arguments in the future.