### PR TITLE
Lower default line limit for railway CLI

### DIFF
--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -77,7 +77,7 @@ describe("Railway Logs Module", () => {
 
       const command = await buildLogCommand("deployment");
 
-      expect(command).toBe("railway logs --deployment --json --lines 1000");
+      expect(command).toBe("railway logs --deployment --json --lines 100");
     });
 
     it("should not include lines/filter for older CLI versions", async () => {

--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -119,7 +119,7 @@ describe("Railway Logs Module", () => {
       const command = await buildLogCommand("deployment", "deploy-123");
 
       expect(command).toBe(
-        "railway logs --deployment --json --lines 1000 deploy-123"
+        "railway logs --deployment --json --lines 100 deploy-123"
       );
     });
 

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -18,7 +18,7 @@ export const buildLogCommand = async (
 
   if (supportsLinesAndFilter) {
     // Always use --lines when specified to prevent streaming
-    args.push("--lines", lines ? lines.toString() : "100");
+    args.push("--lines", lines ? lines.toString() : "1000");
 
     if (filter) {
       args.push("--filter", `"${filter}"`);

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -18,7 +18,7 @@ export const buildLogCommand = async (
 
   if (supportsLinesAndFilter) {
     // Always use --lines when specified to prevent streaming
-    args.push("--lines", lines ? lines.toString() : "1000");
+    args.push("--lines", lines ? lines.toString() : "100");
 
     if (filter) {
       args.push("--filter", `"${filter}"`);


### PR DESCRIPTION
<img width="1129" height="186" alt="image" src="https://github.com/user-attachments/assets/dfc1fa0f-6f00-4e75-a84c-1c9e1a9d5113" />

Build logs are verbose w/ a lot of tags, so lets default to a lower window

This doesn't fail if I try to ask for build logs w/o limiting lines:

<img width="1038" height="307" alt="image" src="https://github.com/user-attachments/assets/f83f9bfc-e3d0-4c55-9369-b734cd39f641" />
