### PR TITLE
Default to JSON off for logs and expose JSON option to MCP tool

### DIFF
--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -77,7 +77,7 @@ describe("Railway Logs Module", () => {
 
       const command = await buildLogCommand("deployment");
 
-      expect(command).toBe("railway logs --deployment --json --lines 1000");
+      expect(command).toBe("railway logs --deployment --json --lines 100");
     });
 
     it("should not include lines/filter for older CLI versions", async () => {

--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -23,17 +23,14 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand(
-        "deployment",
-        undefined,
-        undefined,
-        undefined,
-        100,
-        "error"
-      );
+      const command = await buildLogCommand({
+        type: "deployment",
+        lines: 100,
+        filter: "error",
+      });
 
       expect(command).toBe(
-        'railway logs --deployment --json --lines 100 --filter "error"'
+        'railway logs --deployment --lines 100 --filter "error"'
       );
     });
 
@@ -49,21 +46,18 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand(
-        "build",
-        undefined,
-        undefined,
-        undefined,
-        200,
-        "warning"
-      );
+      const command = await buildLogCommand({
+        type: "build",
+        lines: 200,
+        filter: "warning",
+      });
 
       expect(command).toBe(
-        'railway logs --build --json --lines 200 --filter "warning"'
+        'railway logs --build --lines 200 --filter "warning"'
       );
     });
 
-    it("should default to 1000 lines when not specified for v4.9.0+", async () => {
+    it("should default to 500 lines when json is false", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
@@ -75,7 +69,24 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand("deployment");
+      const command = await buildLogCommand({ type: "deployment" });
+
+      expect(command).toBe("railway logs --deployment --lines 500");
+    });
+
+    it("should default to 100 lines when json is true", async () => {
+      const { getCliFeatureSupport } = await import("./version");
+
+      vi.mocked(getCliFeatureSupport).mockResolvedValue({
+        logs: {
+          args: {
+            lines: true,
+            filter: true,
+          },
+        },
+      });
+
+      const command = await buildLogCommand({ type: "deployment", json: true });
 
       expect(command).toBe("railway logs --deployment --json --lines 100");
     });
@@ -92,16 +103,13 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand(
-        "deployment",
-        undefined,
-        undefined,
-        undefined,
-        100, // Should be ignored
-        "error" // Should be ignored
-      );
+      const command = await buildLogCommand({
+        type: "deployment",
+        lines: 100, // Should be ignored
+        filter: "error", // Should be ignored
+      });
 
-      expect(command).toBe("railway logs --deployment --json");
+      expect(command).toBe("railway logs --deployment");
     });
 
     it("should include deploymentId when provided", async () => {
@@ -116,11 +124,12 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand("deployment", "deploy-123");
+      const command = await buildLogCommand({
+        type: "deployment",
+        deploymentId: "deploy-123",
+      });
 
-      expect(command).toBe(
-        "railway logs --deployment --json --lines 100 deploy-123"
-      );
+      expect(command).toBe("railway logs --deployment --lines 500 deploy-123");
     });
 
     it("should include service and environment when provided", async () => {
@@ -135,16 +144,15 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand(
-        "deployment",
-        undefined,
-        "api",
-        "production",
-        50
-      );
+      const command = await buildLogCommand({
+        type: "deployment",
+        service: "api",
+        environment: "production",
+        lines: 50,
+      });
 
       expect(command).toBe(
-        "railway logs --deployment --json --lines 50 --service api --environment production"
+        "railway logs --deployment --lines 50 --service api --environment production"
       );
     });
 
@@ -160,18 +168,81 @@ describe("Railway Logs Module", () => {
         },
       });
 
-      const command = await buildLogCommand(
-        "build",
-        "deploy-456",
-        "backend",
-        "staging",
-        75,
-        "timeout"
-      );
+      const command = await buildLogCommand({
+        type: "build",
+        deploymentId: "deploy-456",
+        service: "backend",
+        environment: "staging",
+        lines: 75,
+        filter: "timeout",
+      });
 
       expect(command).toBe(
-        'railway logs --build --json --lines 75 --filter "timeout" deploy-456 --service backend --environment staging'
+        'railway logs --build --lines 75 --filter "timeout" deploy-456 --service backend --environment staging'
       );
+    });
+
+    it("should not include --json flag when json is false", async () => {
+      const { getCliFeatureSupport } = await import("./version");
+
+      vi.mocked(getCliFeatureSupport).mockResolvedValue({
+        logs: {
+          args: {
+            lines: true,
+            filter: true,
+          },
+        },
+      });
+
+      const command = await buildLogCommand({
+        type: "deployment",
+        lines: 100,
+        json: false,
+      });
+
+      expect(command).toBe("railway logs --deployment --lines 100");
+    });
+
+    it("should not include --json flag when undefined", async () => {
+      const { getCliFeatureSupport } = await import("./version");
+
+      vi.mocked(getCliFeatureSupport).mockResolvedValue({
+        logs: {
+          args: {
+            lines: true,
+            filter: true,
+          },
+        },
+      });
+
+      const command = await buildLogCommand({
+        type: "deployment",
+        lines: 100,
+        json: false,
+      });
+
+      expect(command).toBe("railway logs --deployment --lines 100");
+    });
+
+    it("should include --json flag when true", async () => {
+      const { getCliFeatureSupport } = await import("./version");
+
+      vi.mocked(getCliFeatureSupport).mockResolvedValue({
+        logs: {
+          args: {
+            lines: true,
+            filter: true,
+          },
+        },
+      });
+
+      const command = await buildLogCommand({
+        type: "deployment",
+        lines: 100,
+        json: true,
+      });
+
+      expect(command).toBe("railway logs --deployment --json --lines 100");
     });
   });
 });

--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -119,7 +119,7 @@ describe("Railway Logs Module", () => {
       const command = await buildLogCommand("deployment", "deploy-123");
 
       expect(command).toBe(
-        "railway logs --deployment --json --lines 1000 deploy-123"
+        "railway logs --deployment --json --lines 100 deploy-123"
       );
     });
 

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -18,7 +18,7 @@ export const buildLogCommand = async (
 
   if (supportsLinesAndFilter) {
     // Always use --lines when specified to prevent streaming
-    args.push("--lines", lines ? lines.toString() : "100");
+    args.push("--lines", lines ? lines.toString() : "1000");
 
     if (filter) {
       args.push("--filter", `"${filter}"`);

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -18,7 +18,7 @@ export const buildLogCommand = async (
 
   if (supportsLinesAndFilter) {
     // Always use --lines when specified to prevent streaming
-    args.push("--lines", lines ? lines.toString() : "1000");
+    args.push("--lines", lines ? lines.toString() : "100");
 
     if (filter) {
       args.push("--filter", `"${filter}"`);

--- a/src/tools/get-logs.ts
+++ b/src/tools/get-logs.ts
@@ -8,13 +8,14 @@ type GetLogsOptions = {
   logType: "build" | "deploy";
   lines?: number;
   filter?: string;
+  json?: boolean;
 } & GetLogsOptionsType;
 
 export const getLogsTool = {
   name: "get-logs",
   title: "Get Railway Logs",
   description:
-    "Get build or deployment logs for the currently linked Railway project. You can optionally specify a deployment ID, service, and environment. If no deployment ID is provided, it will get logs from the latest deployment. The 'lines' and 'filter' parameters require Railway CLI v4.9.0+. Use 'lines' to limit the number of log lines (disables streaming) and 'filter' to search logs by terms or attributes (e.g., '@level:error', 'user', '@level:warn AND rate limit'). For older CLI versions, these parameters will be ignored and logs will stream.",
+    "Get build or deployment logs for the currently linked Railway project. You can optionally specify a deployment ID, service, and environment. If no deployment ID is provided, it will get logs from the latest deployment. The 'lines' and 'filter' parameters require Railway CLI v4.9.0+. Use 'lines' to limit the number of log lines (disables streaming) and 'filter' to search logs by terms or attributes (e.g., '@level:error', 'user', '@level:warn AND rate limit'). For older CLI versions, these parameters will be ignored and logs will stream. The 'json' parameter (default: true) formats output as JSON - set to false if you encounter token limits or want plain text output.",
   inputSchema: {
     workspacePath: z
       .string()
@@ -52,6 +53,12 @@ export const getLogsTool = {
       .describe(
         "Filter logs by search terms or attributes. Requires Railway CLI v4.9.0+. Examples: 'error', '@level:error', '@level:warn AND rate limit', 'user login', '@status:500'. See https://docs.railway.com/guides/logs for more info."
       ),
+    json: z
+      .boolean()
+      .optional()
+      .describe(
+        "JSON provides structured log data with more information (e.g. timestamps) but uses more tokens. Defaults to false to save tokens. Set to true for more detailed logs."
+      ),
   },
   handler: async ({
     workspacePath,
@@ -61,6 +68,7 @@ export const getLogsTool = {
     environment,
     lines,
     filter,
+    json = true,
   }: GetLogsOptions) => {
     try {
       const features = await getCliFeatureSupport();
@@ -84,6 +92,7 @@ export const getLogsTool = {
           environment,
           lines,
           filter,
+          json,
         });
       } else {
         result = await getRailwayDeployLogs({
@@ -93,6 +102,7 @@ export const getLogsTool = {
           environment,
           lines,
           filter,
+          json,
         });
       }
 

--- a/src/tools/get-logs.ts
+++ b/src/tools/get-logs.ts
@@ -15,7 +15,7 @@ export const getLogsTool = {
   name: "get-logs",
   title: "Get Railway Logs",
   description:
-    "Get build or deployment logs for the currently linked Railway project. You can optionally specify a deployment ID, service, and environment. If no deployment ID is provided, it will get logs from the latest deployment. The 'lines' and 'filter' parameters require Railway CLI v4.9.0+. Use 'lines' to limit the number of log lines (disables streaming) and 'filter' to search logs by terms or attributes (e.g., '@level:error', 'user', '@level:warn AND rate limit'). For older CLI versions, these parameters will be ignored and logs will stream. The 'json' parameter (default: true) formats output as JSON - set to false if you encounter token limits or want plain text output.",
+    "Get build or deployment logs for the currently linked Railway project. You can optionally specify a deployment ID, service, and environment. If no deployment ID is provided, it will get logs from the latest deployment. The 'lines' and 'filter' parameters require Railway CLI v4.9.0+. Use 'lines' to limit the number of log lines (disables streaming) and 'filter' to search logs by terms or attributes (e.g., '@level:error', 'user', '@level:warn AND rate limit'). For older CLI versions, these parameters will be ignored and logs will stream.",
   inputSchema: {
     workspacePath: z
       .string()

--- a/src/tools/get-logs.ts
+++ b/src/tools/get-logs.ts
@@ -68,7 +68,7 @@ export const getLogsTool = {
     environment,
     lines,
     filter,
-    json = true,
+    json,
   }: GetLogsOptions) => {
     try {
       const features = await getCliFeatureSupport();


### PR DESCRIPTION
# Why

Build logs esp really eat through MCP token limits. It is very easy to hit the limit:

<img width="1143" height="142" alt="image" src="https://github.com/user-attachments/assets/edbb9789-f4e6-4d91-8067-28ad2b21b1c9" />

You can only read like 50 lines from the logs before you hit the limit. That's rough. Claude probably doesn't always need all the JSON data, so lets default to normal output + allow Claude to enable it selectively

# What Changed

- add json param to tool
- apply json arg conditionally in `src/cli/logs.ts` + set the default line limit based on whether requesting json or not

# Test Plan

- Ask claude for more than 50 build logs
- Ask it for a log's timestamp

<img width="1142" height="415" alt="image" src="https://github.com/user-attachments/assets/9d577135-0757-4ee9-92c4-f94b33fdc1a2" />
