### PR TITLE
Encapsulate arguments in quoteArg to account for spaces in names

### DIFF
--- a/src/cli/deployment.test.ts
+++ b/src/cli/deployment.test.ts
@@ -88,7 +88,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --service my-api-service --limit 20",
+        'railway deployment list --service "my-api-service" --limit 20',
         mockWorkspacePath
       );
     });
@@ -108,7 +108,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --environment staging --limit 20",
+        'railway deployment list --environment "staging" --limit 20',
         mockWorkspacePath
       );
     });

--- a/src/cli/deployment.ts
+++ b/src/cli/deployment.ts
@@ -3,6 +3,7 @@ import { analyzeRailwayError } from "./error-handling";
 import { getLinkedProjectInfo } from "./projects";
 import { getRailwayServices } from "./services";
 import { getCliFeatureSupport, getRailwayVersion } from "./version";
+import { quoteArg } from "../utils";
 
 export type DeployOptions = {
   workspacePath: string;
@@ -32,11 +33,11 @@ export const deployRailwayProject = async ({
     }
 
     if (environment) {
-      command += ` --environment ${environment}`;
+      command += ` --environment ${quoteArg(environment)}`;
     }
 
     if (service) {
-      command += ` --service ${service}`;
+      command += ` --service ${quoteArg(service)}`;
     }
 
     const { output: deployOutput } = await runRailwayCommand(
@@ -56,7 +57,7 @@ export const deployRailwayProject = async ({
         // Link the first available service
         const firstService = servicesResult.services[0];
         const { output: linkOutput } = await runRailwayCommand(
-          `railway service ${firstService}`,
+          `railway service ${quoteArg(firstService)}`,
           workspacePath
         );
         return `${deployOutput}\n\nService linked: ${firstService}\n${linkOutput}`;
@@ -135,11 +136,11 @@ export const listDeployments = async ({
     let command = "railway deployment list";
 
     if (service) {
-      command += ` --service ${service}`;
+      command += ` --service ${quoteArg(service)}`;
     }
 
     if (environment) {
-      command += ` --environment ${environment}`;
+      command += ` --environment ${quoteArg(environment)}`;
     }
 
     if (limit) {

--- a/src/cli/domain.ts
+++ b/src/cli/domain.ts
@@ -1,6 +1,7 @@
 import { checkRailwayCliStatus, runRailwayJsonCommand } from "./core";
 import { analyzeRailwayError } from "./error-handling";
 import { getLinkedProjectInfo } from "./projects";
+import { quoteArg } from "../utils";
 
 export type GenerateDomainOptions = {
   workspacePath: string;
@@ -22,7 +23,7 @@ export const generateRailwayDomain = async ({
     let command = "railway domain --json";
 
     if (service) {
-      command += ` --service ${service}`;
+      command += ` --service ${quoteArg(service)}`;
     }
 
     const domainResult = await runRailwayJsonCommand(command, workspacePath);

--- a/src/cli/environments.ts
+++ b/src/cli/environments.ts
@@ -5,6 +5,7 @@ import {
 } from "./core";
 import { analyzeRailwayError } from "./error-handling";
 import { getLinkedProjectInfo } from "./projects";
+import { quoteArg } from "../utils";
 
 export type GetCurrentEnvironmentIdOptions = {
 	workspacePath: string;
@@ -77,7 +78,7 @@ export const linkRailwayEnvironment = async ({
 		}
 
 		const command = environmentName
-			? `railway environment ${environmentName}`
+			? `railway environment ${quoteArg(environmentName)}`
 			: "railway environment";
 		const { output } = await runRailwayCommand(command, workspacePath);
 
@@ -107,15 +108,15 @@ export const createRailwayEnvironment = async ({
 			throw new Error(result.error);
 		}
 
-		let command = `railway environment new ${environmentName}`;
+		let command = `railway environment new ${quoteArg(environmentName)}`;
 
 		if (duplicateEnvironment) {
-			command += ` --duplicate ${duplicateEnvironment}`;
+			command += ` --duplicate ${quoteArg(duplicateEnvironment)}`;
 		}
 
 		if (serviceVariables && serviceVariables.length > 0) {
 			for (const sv of serviceVariables) {
-				command += ` --service-variable ${sv.service} ${sv.variable}`;
+				command += ` --service-variable ${quoteArg(sv.service)} ${quoteArg(sv.variable)}`;
 			}
 		}
 

--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -174,7 +174,7 @@ describe("Railway Logs Module", () => {
       });
 
       expect(command).toBe(
-        "railway logs --deployment --lines 50 --service api --environment production"
+        'railway logs --deployment --lines 50 --service "api" --environment "production"'
       );
     });
 
@@ -203,7 +203,7 @@ describe("Railway Logs Module", () => {
       });
 
       expect(command).toBe(
-        'railway logs --build --lines 75 --filter "timeout" deploy-456 --service backend --environment staging'
+        'railway logs --build --lines 75 --filter "timeout" deploy-456 --service "backend" --environment "staging"'
       );
     });
 

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -2,6 +2,7 @@ import { checkRailwayCliStatus, runRailwayCommand } from "./core";
 import { getCliFeatureSupport } from "./version";
 import { analyzeRailwayError } from "./error-handling";
 import { getLinkedProjectInfo } from "./projects";
+import { quoteArg } from "../utils";
 
 type BuildLogCommandOptions = {
   type: "deployment" | "build";
@@ -45,8 +46,8 @@ export const buildLogCommand = async ({
   }
 
   if (deploymentId) args.push(deploymentId);
-  if (service) args.push("--service", service);
-  if (environment) args.push("--environment", environment);
+  if (service) args.push("--service", quoteArg(service));
+  if (environment) args.push("--environment", quoteArg(environment));
 
   return `railway ${args.join(" ")}`;
 };

--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -1,6 +1,7 @@
 import { checkRailwayCliStatus, runRailwayCommand } from "./core";
 import { analyzeRailwayError } from "./error-handling";
 import { getLinkedProjectInfo } from "./projects";
+import { quoteArg } from "../utils";
 
 export type GetServicesOptions = {
 	workspacePath: string;
@@ -58,7 +59,7 @@ export const linkRailwayService = async ({
 		}
 
 		const { output } = await runRailwayCommand(
-			`railway service ${serviceName}`,
+			`railway service ${quoteArg(serviceName)}`,
 			workspacePath,
 		);
 

--- a/src/cli/variables.ts
+++ b/src/cli/variables.ts
@@ -1,6 +1,7 @@
 import { checkRailwayCliStatus, runRailwayCommand } from "./core";
 import { analyzeRailwayError } from "./error-handling";
 import { getLinkedProjectInfo } from "./projects";
+import { quoteArg } from "../utils";
 
 export type ListVariablesOptions = {
 	workspacePath: string;
@@ -27,10 +28,10 @@ export const listRailwayVariables = async ({
 		let command = "railway variables";
 
 		if (service) {
-			command += ` --service ${service}`;
+			command += ` --service ${quoteArg(service)}`;
 		}
 		if (environment) {
-			command += ` --environment ${environment}`;
+			command += ` --environment ${quoteArg(environment)}`;
 		}
 		if (kv) {
 			command += " --kv";
@@ -71,10 +72,10 @@ export const setRailwayVariables = async ({
 		let command = "railway variables";
 
 		if (service) {
-			command += ` --service ${service}`;
+			command += ` --service ${quoteArg(service)}`;
 		}
 		if (environment) {
-			command += ` --environment ${environment}`;
+			command += ` --environment ${quoteArg(environment)}`;
 		}
 		if (skipDeploys) {
 			command += " --skip-deploys";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,3 +21,9 @@ export const getVersion = (): string => {
 export const createToolResponse = (text: string) => ({
 	content: [{ type: "text" as const, text }],
 });
+
+/**
+ * Quotes a shell argument to handle spaces and special characters.
+ * Returns the argument wrapped in double quotes.
+ */
+export const quoteArg = (arg: string): string => `"${arg}"`;


### PR DESCRIPTION
`⏺ Railway - list-variables (MCP)(workspacePath: "{workspacePath}", service: Downloads Worker, json: true)`

Had issues with the MCP where the service name wasn't escaped properly if it included spaces, so made a function to encapsulate argument names in spaces.