### PR TITLE
refactor(cli): pass argv as arrays to railway invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@railway/mcp-server",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "mcpName": "io.github.railwayapp/mcp-server",
   "description": "Official Railway MCP server",
   "author": "Railway",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/railwayapp/railway-mcp-server",
     "source": "github"
   },
-  "version": "0.1.8",
+  "version": "0.1.9",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@railway/mcp-server",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "transport": {
         "type": "stdio"
       }

--- a/src/cli/core.ts
+++ b/src/cli/core.ts
@@ -1,23 +1,26 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { analyzeRailwayError } from "./error-handling";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
-export const runRailwayCommand = async (command: string, cwd?: string) => {
-  const { stdout, stderr } = await execAsync(command, { cwd });
+// Pass argv as an array. We invoke `railway` directly via execFile, so no shell
+// is involved and metacharacters in user-supplied arguments cannot be parsed
+// as commands.
+export const runRailwayCommand = async (args: string[], cwd?: string) => {
+  const { stdout, stderr } = await execFileAsync("railway", args, { cwd });
   return { stdout, stderr, output: stdout + stderr };
 };
 
-export const runRailwayJsonCommand = async (command: string, cwd?: string) => {
-  const { stdout } = await runRailwayCommand(command, cwd);
+export const runRailwayJsonCommand = async (args: string[], cwd?: string) => {
+  const { stdout } = await runRailwayCommand(args, cwd);
   return JSON.parse(stdout.trim());
 };
 
 export const checkRailwayCliStatus = async (): Promise<void> => {
   try {
-    await runRailwayCommand("railway --version");
-    await runRailwayCommand("railway whoami");
+    await runRailwayCommand(["--version"]);
+    await runRailwayCommand(["whoami"]);
   } catch (error: unknown) {
     return analyzeRailwayError(error, "railway whoami");
   }

--- a/src/cli/deployment.test.ts
+++ b/src/cli/deployment.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as core from "./core";
 import { listDeployments } from "./deployment";
-import * as errorHandling from "./error-handling";
 import type { RailwayProject } from "./projects";
 import * as projects from "./projects";
 import * as version from "./version";
@@ -62,7 +61,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --limit 20",
+        ["deployment", "list", "--limit", "20"],
         mockWorkspacePath
       );
     });
@@ -75,7 +74,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --limit 20 --json",
+        ["deployment", "list", "--limit", "20", "--json"],
         mockWorkspacePath
       );
     });
@@ -88,7 +87,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --service my-api-service --limit 20",
+        ["deployment", "list", "--service", "my-api-service", "--limit", "20"],
         mockWorkspacePath
       );
     });
@@ -108,7 +107,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --environment staging --limit 20",
+        ["deployment", "list", "--environment", "staging", "--limit", "20"],
         mockWorkspacePath
       );
     });
@@ -128,7 +127,7 @@ describe("listDeployments", () => {
 
       expect(result.success).toBe(true);
       expect(core.runRailwayCommand).toHaveBeenCalledWith(
-        "railway deployment list --limit 50",
+        ["deployment", "list", "--limit", "50"],
         mockWorkspacePath
       );
     });

--- a/src/cli/deployment.ts
+++ b/src/cli/deployment.ts
@@ -24,45 +24,31 @@ export const deployRailwayProject = async ({
       throw new Error(result.error);
     }
 
-    // Build the railway up command with options
-    let command = "railway up";
-
-    if (ci) {
-      command += " --ci";
-    }
-
-    if (environment) {
-      command += ` --environment ${environment}`;
-    }
-
-    if (service) {
-      command += ` --service ${service}`;
-    }
+    const args = ["up"];
+    if (ci) args.push("--ci");
+    if (environment) args.push("--environment", environment);
+    if (service) args.push("--service", service);
 
     const { output: deployOutput } = await runRailwayCommand(
-      command,
+      args,
       workspacePath
     );
 
-    // After deployment, try to link a service if none is linked
     try {
-      // Check if there are any services available
       const servicesResult = await getRailwayServices({ workspacePath });
       if (
         servicesResult.success &&
         servicesResult.services &&
         servicesResult.services.length > 0
       ) {
-        // Link the first available service
         const firstService = servicesResult.services[0];
         const { output: linkOutput } = await runRailwayCommand(
-          `railway service ${firstService}`,
+          ["service", firstService],
           workspacePath
         );
         return `${deployOutput}\n\nService linked: ${firstService}\n${linkOutput}`;
       }
     } catch (linkError) {
-      // If linking fails, just return the deployment output
       console.warn(
         "Warning: Could not automatically link service after deployment:",
         linkError
@@ -132,25 +118,13 @@ export const listDeployments = async ({
       };
     }
 
-    let command = "railway deployment list";
+    const args = ["deployment", "list"];
+    if (service) args.push("--service", service);
+    if (environment) args.push("--environment", environment);
+    if (limit) args.push("--limit", String(limit));
+    if (json) args.push("--json");
 
-    if (service) {
-      command += ` --service ${service}`;
-    }
-
-    if (environment) {
-      command += ` --environment ${environment}`;
-    }
-
-    if (limit) {
-      command += ` --limit ${limit}`;
-    }
-
-    if (json) {
-      command += " --json";
-    }
-
-    const { output } = await runRailwayCommand(command, workspacePath);
+    const { output } = await runRailwayCommand(args, workspacePath);
     return { success: true, output };
   } catch (error: unknown) {
     return analyzeRailwayError(error, `railway deployment list`);

--- a/src/cli/domain.ts
+++ b/src/cli/domain.ts
@@ -18,14 +18,10 @@ export const generateRailwayDomain = async ({
       throw new Error(projectResult.error);
     }
 
-    // Build the railway domain command with options
-    let command = "railway domain --json";
+    const args = ["domain", "--json"];
+    if (service) args.push("--service", service);
 
-    if (service) {
-      command += ` --service ${service}`;
-    }
-
-    const domainResult = await runRailwayJsonCommand(command, workspacePath);
+    const domainResult = await runRailwayJsonCommand(args, workspacePath);
 
     if (domainResult.domain) {
       return domainResult.domain;

--- a/src/cli/environments.ts
+++ b/src/cli/environments.ts
@@ -20,14 +20,11 @@ export const getCurrentEnvironmentId = async ({
 			throw new Error(result.error);
 		}
 
-		// First, get the current environment name from railway status
 		const { output: statusOutput } = await runRailwayCommand(
-			"railway status",
+			["status"],
 			workspacePath,
 		);
 
-		// Parse the output to extract current environment name
-		// The output format is typically: "Environment: production"
 		const envNameMatch = statusOutput.match(/Environment:\s+(\w+)/);
 		if (!envNameMatch?.[1]) {
 			throw new Error("Could not determine current environment name");
@@ -35,13 +32,11 @@ export const getCurrentEnvironmentId = async ({
 
 		const currentEnvironmentName = envNameMatch[1];
 
-		// Get detailed environment information using railway status --json
 		const statusData = await runRailwayJsonCommand(
-			"railway status --json",
+			["status", "--json"],
 			workspacePath,
 		);
 
-		// Find the environment ID that matches the current environment name
 		if (statusData.environments?.edges?.length > 0) {
 			for (const envEdge of statusData.environments.edges) {
 				const env = envEdge.node;
@@ -51,7 +46,6 @@ export const getCurrentEnvironmentId = async ({
 			}
 		}
 
-		// If we can't find the environment ID, throw an error
 		throw new Error(
 			`Could not determine environment ID for environment: ${currentEnvironmentName}`,
 		);
@@ -76,10 +70,10 @@ export const linkRailwayEnvironment = async ({
 			throw new Error(result.error);
 		}
 
-		const command = environmentName
-			? `railway environment ${environmentName}`
-			: "railway environment";
-		const { output } = await runRailwayCommand(command, workspacePath);
+		const args = environmentName
+			? ["environment", environmentName]
+			: ["environment"];
+		const { output } = await runRailwayCommand(args, workspacePath);
 
 		return output;
 	} catch (error: unknown) {
@@ -107,19 +101,19 @@ export const createRailwayEnvironment = async ({
 			throw new Error(result.error);
 		}
 
-		let command = `railway environment new ${environmentName}`;
+		const args = ["environment", "new", environmentName];
 
 		if (duplicateEnvironment) {
-			command += ` --duplicate ${duplicateEnvironment}`;
+			args.push("--duplicate", duplicateEnvironment);
 		}
 
 		if (serviceVariables && serviceVariables.length > 0) {
 			for (const sv of serviceVariables) {
-				command += ` --service-variable ${sv.service} ${sv.variable}`;
+				args.push("--service-variable", sv.service, sv.variable);
 			}
 		}
 
-		const { output } = await runRailwayCommand(command, workspacePath);
+		const { output } = await runRailwayCommand(args, workspacePath);
 
 		return output;
 	} catch (error: unknown) {

--- a/src/cli/logs.test.ts
+++ b/src/cli/logs.test.ts
@@ -15,15 +15,8 @@ describe("Railway Logs Module", () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -32,24 +25,22 @@ describe("Railway Logs Module", () => {
         filter: "error",
       });
 
-      expect(command).toBe(
-        'railway logs --deployment --lines 100 --filter "error"'
-      );
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--lines",
+        "100",
+        "--filter",
+        "error",
+      ]);
     });
 
     it("should build build command with lines and filter for v4.9.0+", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -58,65 +49,54 @@ describe("Railway Logs Module", () => {
         filter: "warning",
       });
 
-      expect(command).toBe(
-        'railway logs --build --lines 200 --filter "warning"'
-      );
+      expect(command).toEqual([
+        "logs",
+        "--build",
+        "--lines",
+        "200",
+        "--filter",
+        "warning",
+      ]);
     });
 
     it("should default to 500 lines when json is false", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({ type: "deployment" });
 
-      expect(command).toBe("railway logs --deployment --lines 500");
+      expect(command).toEqual(["logs", "--deployment", "--lines", "500"]);
     });
 
     it("should default to 100 lines when json is true", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({ type: "deployment", json: true });
 
-      expect(command).toBe("railway logs --deployment --json --lines 100");
-      expect(command).toBe("railway logs --deployment --json --lines 100");
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--json",
+        "--lines",
+        "100",
+      ]);
     });
 
     it("should not include lines/filter for older CLI versions", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: false,
-            filter: false,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: false, filter: false } },
       });
 
       const command = await buildLogCommand({
@@ -125,22 +105,15 @@ describe("Railway Logs Module", () => {
         filter: "error", // Should be ignored
       });
 
-      expect(command).toBe("railway logs --deployment");
+      expect(command).toEqual(["logs", "--deployment"]);
     });
 
     it("should include deploymentId when provided", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -148,22 +121,21 @@ describe("Railway Logs Module", () => {
         deploymentId: "deploy-123",
       });
 
-      expect(command).toBe("railway logs --deployment --lines 500 deploy-123");
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--lines",
+        "500",
+        "deploy-123",
+      ]);
     });
 
     it("should include service and environment when provided", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -173,24 +145,24 @@ describe("Railway Logs Module", () => {
         lines: 50,
       });
 
-      expect(command).toBe(
-        "railway logs --deployment --lines 50 --service api --environment production"
-      );
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--lines",
+        "50",
+        "--service",
+        "api",
+        "--environment",
+        "production",
+      ]);
     });
 
     it("should handle all parameters together", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -202,24 +174,27 @@ describe("Railway Logs Module", () => {
         filter: "timeout",
       });
 
-      expect(command).toBe(
-        'railway logs --build --lines 75 --filter "timeout" deploy-456 --service backend --environment staging'
-      );
+      expect(command).toEqual([
+        "logs",
+        "--build",
+        "--lines",
+        "75",
+        "--filter",
+        "timeout",
+        "deploy-456",
+        "--service",
+        "backend",
+        "--environment",
+        "staging",
+      ]);
     });
 
     it("should not include --json flag when json is false", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -228,22 +203,20 @@ describe("Railway Logs Module", () => {
         json: false,
       });
 
-      expect(command).toBe("railway logs --deployment --lines 100");
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--lines",
+        "100",
+      ]);
     });
 
     it("should not include --json flag when undefined", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -252,22 +225,20 @@ describe("Railway Logs Module", () => {
         json: false,
       });
 
-      expect(command).toBe("railway logs --deployment --lines 100");
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--lines",
+        "100",
+      ]);
     });
 
     it("should include --json flag when true", async () => {
       const { getCliFeatureSupport } = await import("./version");
 
       vi.mocked(getCliFeatureSupport).mockResolvedValue({
-        deployment: {
-          list: true,
-        },
-        logs: {
-          args: {
-            lines: true,
-            filter: true,
-          },
-        },
+        deployment: { list: true },
+        logs: { args: { lines: true, filter: true } },
       });
 
       const command = await buildLogCommand({
@@ -276,7 +247,13 @@ describe("Railway Logs Module", () => {
         json: true,
       });
 
-      expect(command).toBe("railway logs --deployment --json --lines 100");
+      expect(command).toEqual([
+        "logs",
+        "--deployment",
+        "--json",
+        "--lines",
+        "100",
+      ]);
     });
   });
 });

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -21,11 +21,9 @@ export const buildLogCommand = async ({
   lines,
   filter,
   json = false,
-}: BuildLogCommandOptions): Promise<string> => {
+}: BuildLogCommandOptions): Promise<string[]> => {
   const args = ["logs", `--${type}`];
-  if (json) {
-    args.push("--json");
-  }
+  if (json) args.push("--json");
 
   const features = await getCliFeatureSupport();
   const supportsLinesAndFilter =
@@ -36,19 +34,16 @@ export const buildLogCommand = async ({
     // turned on.
     const defaultLines = json ? "100" : "500";
 
-    // Always use --lines when specified to prevent streaming
     args.push("--lines", lines ? lines.toString() : defaultLines);
 
-    if (filter) {
-      args.push("--filter", `"${filter}"`);
-    }
+    if (filter) args.push("--filter", filter);
   }
 
   if (deploymentId) args.push(deploymentId);
   if (service) args.push("--service", service);
   if (environment) args.push("--environment", environment);
 
-  return `railway ${args.join(" ")}`;
+  return args;
 };
 
 export type GetLogsOptions = Pick<
@@ -67,7 +62,7 @@ export const getRailwayDeployLogs = async ({
   filter,
   json,
 }: GetLogsOptions): Promise<string> => {
-  const command = await buildLogCommand({
+  const args = await buildLogCommand({
     type: "deployment",
     deploymentId,
     service,
@@ -84,11 +79,11 @@ export const getRailwayDeployLogs = async ({
       throw new Error(result.error);
     }
 
-    const { output } = await runRailwayCommand(command, workspacePath);
+    const { output } = await runRailwayCommand(args, workspacePath);
 
     return output;
   } catch (error: unknown) {
-    return analyzeRailwayError(error, command);
+    return analyzeRailwayError(error, `railway ${args.join(" ")}`);
   }
 };
 
@@ -101,7 +96,7 @@ export const getRailwayBuildLogs = async ({
   filter,
   json,
 }: GetLogsOptions): Promise<string> => {
-  const command = await buildLogCommand({
+  const args = await buildLogCommand({
     type: "build",
     deploymentId,
     service,
@@ -117,10 +112,10 @@ export const getRailwayBuildLogs = async ({
       throw new Error(result.error);
     }
 
-    const { output } = await runRailwayCommand(command, workspacePath);
+    const { output } = await runRailwayCommand(args, workspacePath);
 
     return output;
   } catch (error: unknown) {
-    return analyzeRailwayError(error, command);
+    return analyzeRailwayError(error, `railway ${args.join(" ")}`);
   }
 };

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -43,7 +43,7 @@ export const getLinkedProjectInfo = async ({
 	try {
 		await checkRailwayCliStatus();
 		const project = await runRailwayJsonCommand(
-			"railway status --json",
+			["status", "--json"],
 			workspacePath,
 		);
 
@@ -55,7 +55,6 @@ export const getLinkedProjectInfo = async ({
 	} catch (error: unknown) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 
-		// Check if it's a "no linked project" error
 		if (ERROR_PATTERNS.NO_LINKED_PROJECT.test(errorMessage)) {
 			return {
 				success: false,
@@ -71,7 +70,7 @@ export const getLinkedProjectInfo = async ({
 export const listRailwayProjects = async (): Promise<RailwayProject[]> => {
 	try {
 		await checkRailwayCliStatus();
-		const projects = await runRailwayJsonCommand("railway list --json");
+		const projects = await runRailwayJsonCommand(["list", "--json"]);
 
 		if (!Array.isArray(projects)) {
 			throw new Error("Unexpected response format from Railway CLI");
@@ -95,18 +94,17 @@ export const createRailwayProject = async ({
 	try {
 		await checkRailwayCliStatus();
 
-		// Check if there's already a linked project
 		const linkedProjectResult = await getLinkedProjectInfo({ workspacePath });
 		if (linkedProjectResult.success && linkedProjectResult.project) {
 			return "A Railway project is already linked to this workspace. No new project created.";
 		}
 
 		const { output: initOutput } = await runRailwayCommand(
-			`railway init --name ${projectName}`,
+			["init", "--name", projectName],
 			workspacePath,
 		);
 		const { output: linkOutput } = await runRailwayCommand(
-			`railway link -p ${projectName}`,
+			["link", "-p", projectName],
 			workspacePath,
 		);
 

--- a/src/cli/services.ts
+++ b/src/cli/services.ts
@@ -21,14 +21,12 @@ export const getRailwayServices = async ({
 		}
 
 		const { output } = await runRailwayCommand(
-			"railway status --json",
+			["status", "--json"],
 			workspacePath,
 		);
 
-		// Parse the JSON output to extract services
 		const statusData = JSON.parse(output);
 
-		// Extract services from the JSON structure
 		const services =
 			statusData.services?.edges?.map(
 				(edge: { node: { name: string } }) => edge.node.name,
@@ -58,7 +56,7 @@ export const linkRailwayService = async ({
 		}
 
 		const { output } = await runRailwayCommand(
-			`railway service ${serviceName}`,
+			["service", serviceName],
 			workspacePath,
 		);
 

--- a/src/cli/variables.ts
+++ b/src/cli/variables.ts
@@ -24,22 +24,14 @@ export const listRailwayVariables = async ({
 			throw new Error(result.error);
 		}
 
-		let command = "railway variables";
+		const args = ["variables"];
 
-		if (service) {
-			command += ` --service ${service}`;
-		}
-		if (environment) {
-			command += ` --environment ${environment}`;
-		}
-		if (kv) {
-			command += " --kv";
-		}
-		if (json) {
-			command += " --json";
-		}
+		if (service) args.push("--service", service);
+		if (environment) args.push("--environment", environment);
+		if (kv) args.push("--kv");
+		if (json) args.push("--json");
 
-		const { output } = await runRailwayCommand(command, workspacePath);
+		const { output } = await runRailwayCommand(args, workspacePath);
 		return output;
 	} catch (error: unknown) {
 		return analyzeRailwayError(error, "railway variables");
@@ -68,24 +60,17 @@ export const setRailwayVariables = async ({
 			throw new Error(result.error);
 		}
 
-		let command = "railway variables";
+		const args = ["variables"];
 
-		if (service) {
-			command += ` --service ${service}`;
-		}
-		if (environment) {
-			command += ` --environment ${environment}`;
-		}
-		if (skipDeploys) {
-			command += " --skip-deploys";
+		if (service) args.push("--service", service);
+		if (environment) args.push("--environment", environment);
+		if (skipDeploys) args.push("--skip-deploys");
+
+		for (const variable of variables) {
+			args.push("--set", variable);
 		}
 
-		// Add each variable with --set flag
-		variables.forEach((variable) => {
-			command += ` --set "${variable}"`;
-		});
-
-		const { output } = await runRailwayCommand(command, workspacePath);
+		const { output } = await runRailwayCommand(args, workspacePath);
 		return output;
 	} catch (error: unknown) {
 		return analyzeRailwayError(error, "railway variables --set");

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -20,7 +20,7 @@ export const getRailwayVersion = async (): Promise<string | null> => {
   }
 
   try {
-    const { stdout } = await runRailwayCommand("railway --version");
+    const { stdout } = await runRailwayCommand(["--version"]);
     // Use semver.coerce to extract a valid semver from various formats
     // This handles "railway 4.9.0", "railway version 4.9.0", "4.9.0", etc.
     const version = semver.coerce(stdout);


### PR DESCRIPTION
Internal refactor: `runRailwayCommand` now takes `string[]` and invokes the railway binary via `execFile` instead of `exec`. Call sites updated accordingly. No external API changes.