### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -38,9 +38,7 @@ jobs:
         run: pnpm run build
         
       - name: Publish to npm
-        run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Install MCP Publisher
         run: |


### PR DESCRIPTION
## Summary
- Drop `NPM_TOKEN` from the publish workflow in favor of npm's [Trusted Publisher](https://docs.npmjs.com/trusted-publishers) OIDC flow, which is already configured for `@railway/mcp-server` → this repo's `publish-mcp.yml`.
- The job already declared `id-token: write`, so removing `NODE_AUTH_TOKEN` is the only change required. Added `--access public` to match the pattern used in `railwayapp/cli`'s release workflow.

After this lands, the `NPM_TOKEN` repo secret can be deleted.

## Test plan
- [ ] Cut a tag (`v*`) and confirm the `Publish to npm` step succeeds without `NODE_AUTH_TOKEN`
- [ ] Confirm the published version shows provenance on npmjs.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)