### PR TITLE
ci: upgrade npm to 11.14.1 for OIDC trusted publishing; bump to v0.1.11

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -34,9 +34,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       
-      - name: Build package  
+      - name: Build package
         run: pnpm run build
-        
+
+      - name: Upgrade npm (Trusted Publishing requires npm >= 11.5.1)
+        run: npm install -g npm@11.14.1
+
       - name: Publish to npm
         run: npm publish --provenance --access public
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@railway/mcp-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "mcpName": "io.github.railwayapp/mcp-server",
   "description": "Official Railway MCP server",
   "author": "Railway",

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/railwayapp/railway-mcp-server",
     "source": "github"
   },
-  "version": "0.1.10",
+  "version": "0.1.11",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@railway/mcp-server",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- Upgrade npm to `11.14.1` in the publish workflow before `npm publish`. Node 20 ships with npm 10.8.2, which signs `--provenance` but does not use OIDC for registry auth. OIDC-based publish auth was added in npm 11.5.1.
- Bump `package.json` and `server.json` to `0.1.11`.

## Why

`v0.1.9` and `v0.1.10` both failed publishing with:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@railway%2fmcp-server
npm error 404  '@railway/mcp-server@0.1.X' is not in this registry.
```

Even after configuring the Trusted Publisher on npmjs.com (org `railwayapp`, repo `railway-mcp-server`, workflow `publish-mcp.yml`), npm 10.8.2 ignored OIDC and tried token auth — the token was removed in #32, so the registry rejected the PUT.

Confirmed in the v0.1.10 run logs:

```
publish	Install Node.js (sets registry + auth)	npm: 10.8.2
```

`v0.1.10` was never published, so the tag is orphaned; this PR bumps to `v0.1.11` for a clean re-publish after merge.

## Test plan

- [ ] Merge to main
- [ ] Tag `v0.1.11` from main and push — workflow should publish successfully
- [ ] Verify `@railway/mcp-server@0.1.11` appears on npmjs.com with provenance
- [ ] Verify MCP Registry publish step also succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)