### PR TITLE
Fix Railway CLI shim resolution on Windows

### DIFF
--- a/src/cli/core.test.ts
+++ b/src/cli/core.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getRailwayExecutable } from "./core";
+
+describe("getRailwayExecutable", () => {
+	it("uses the Windows command shim on win32", () => {
+		expect(getRailwayExecutable("win32")).toBe("railway.cmd");
+	});
+
+	it("uses the bare railway executable on non-Windows platforms", () => {
+		expect(getRailwayExecutable("darwin")).toBe("railway");
+		expect(getRailwayExecutable("linux")).toBe("railway");
+	});
+});

--- a/src/cli/core.ts
+++ b/src/cli/core.ts
@@ -4,24 +4,30 @@ import { analyzeRailwayError } from "./error-handling";
 
 const execFileAsync = promisify(execFile);
 
+export const getRailwayExecutable = (
+	platform: NodeJS.Platform = process.platform,
+) => (platform === "win32" ? "railway.cmd" : "railway");
+
 // Pass argv as an array. We invoke `railway` directly via execFile, so no shell
 // is involved and metacharacters in user-supplied arguments cannot be parsed
 // as commands.
 export const runRailwayCommand = async (args: string[], cwd?: string) => {
-  const { stdout, stderr } = await execFileAsync("railway", args, { cwd });
-  return { stdout, stderr, output: stdout + stderr };
+	const { stdout, stderr } = await execFileAsync(getRailwayExecutable(), args, {
+		cwd,
+	});
+	return { stdout, stderr, output: stdout + stderr };
 };
 
 export const runRailwayJsonCommand = async (args: string[], cwd?: string) => {
-  const { stdout } = await runRailwayCommand(args, cwd);
-  return JSON.parse(stdout.trim());
+	const { stdout } = await runRailwayCommand(args, cwd);
+	return JSON.parse(stdout.trim());
 };
 
 export const checkRailwayCliStatus = async (): Promise<void> => {
-  try {
-    await runRailwayCommand(["--version"]);
-    await runRailwayCommand(["whoami"]);
-  } catch (error: unknown) {
-    return analyzeRailwayError(error, "railway whoami");
-  }
+	try {
+		await runRailwayCommand(["--version"]);
+		await runRailwayCommand(["whoami"]);
+	} catch (error: unknown) {
+		return analyzeRailwayError(error, "railway whoami");
+	}
 };


### PR DESCRIPTION
## Summary
- resolve the Railway CLI executable as `railway.cmd` on Windows while keeping `railway` on other platforms
- keep `execFile` with argv arrays, so the command still avoids shell parsing
- add a focused regression test for Windows vs non-Windows executable selection

## Verification
- `corepack pnpm test:run src/cli/core.test.ts`
- `corepack pnpm exec biome check src/cli/core.ts src/cli/core.test.ts`

I also ran `corepack pnpm typecheck`; it currently fails in existing `src/index.ts` MCP SDK handler typing unrelated to this change.

Prepared by an AI agent/operator. Fixes #34.
